### PR TITLE
Update limit ansible-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core==2.16.4
+ansible-core<2.17.0
 ansible-lint
 cryptography==42.0.4
 distlib==0.3.9


### PR DESCRIPTION
ansible-core 2.17 is no longer compatible with AlmaLinux 8 due to dropped support of Python 3.6 (platform-python is 3.6)